### PR TITLE
feat(BE-48):Created the authenticated version of 'Get Company Ranking…

### DIFF
--- a/backend/api/routes/user.py
+++ b/backend/api/routes/user.py
@@ -336,3 +336,62 @@ async def get_company_ranking_history(company_id: str, db: Session = Depends(get
         models.Ranking.created_at.desc()).all()
 
     return rankings
+
+@router.get('/company/ranks/{category}', tags=["User"], )
+def get_company_category(category: str, user: User = Depends(get_current_user)):
+    """
+    This gets the metrics of a company by category for an authenticated user
+    """
+    db: Session = next(get_db())
+
+    # TODO: Validate and ensure the user has active subscription for a low cap company
+    is_user_subscribed = False
+
+    if category == low_cap_category_id and not is_user_subscribed:
+        raise HTTPException(status_code=401,
+                            detail="You must be subscribed before you can access low cap companies")
+    # get companies
+    companies: list = db.query(models.Company).filter(models.Company.category == category).all()
+
+    # get latest rankings
+    rankings: list = []
+    for company in companies:
+        rank = db.query(Ranking).filter(Ranking.company == company.company_id) \
+            .order_by(Ranking.created_at.desc()).first()
+        if rank:
+            rankings.append(rank)
+
+    # sort rankings by score (descending)
+    def get_ranking_sort_key(inner_rank: Ranking):
+        return inner_rank.score
+
+    rankings.sort(key=get_ranking_sort_key, reverse=True)
+
+    # create the response list
+    response = []
+    top_rankings = []
+    for ranking in rankings:
+        if len(top_rankings) == 12:
+            break
+
+        top_rankings.append(ranking)
+
+    for ranking in top_rankings:
+        comp: models.Company = ranking.comp_ranks
+        data = {
+            'company_id': comp.company_id,
+            'name': comp.name,
+            'profile_image': comp.profile_image,
+            'sector': comp.sect_value,
+            'category': comp.cat_value,
+            'ticker_symbol': comp.ticker_value.symbol,
+            'exchange_platform': comp.ticker_value.exchange_name,
+            'current_ranking': {
+                'score': ranking.score,
+                'created_at': ranking.created_at,
+                'updated_at': ranking.updated_at,
+            }
+        }
+        response.append(data)
+
+    return response


### PR DESCRIPTION
This endpoint

- is the authenticated version of the 'Get Company Rankings by Category' endpoint,
- it validates the user's subscription status,
- and uses the information to determine the category of stocks that can be viewed.

Linear link: https://linear.app/team-plug-space/issue/BE-48/create-the-authenticated-version-of-get-company-rankings-by-category