### PR TITLE
BE55-Add Email Verification Support for users creating an account

### DIFF
--- a/backend/api/models/models.py
+++ b/backend/api/models/models.py
@@ -151,6 +151,7 @@ class User(Base):
     email = Column(String(30))
     name = Column(String(30))
     password = Column(String(100))
+    is_verified = Column(Boolean, default=False)
 
     customer = relationship("Customer", back_populates="user_value")
     notifications_settings_value = relationship("NotificationSettings", back_populates="user_value")
@@ -183,6 +184,7 @@ class CreateUserModel(BaseModel):
     email: str
     name: str
     password: str
+    is_verified: bool = None
 
 
 class NotificationSettings(Base):

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4,7 +4,7 @@ from datetime import timedelta, datetime
 from typing import Any, Optional, MutableMapping, Union, List
 
 from dotenv import load_dotenv
-from fastapi import APIRouter, HTTPException, status, Depends
+from fastapi import APIRouter, HTTPException, Request, status, Depends
 from fastapi.security import OAuth2PasswordRequestForm, OAuth2PasswordBearer
 from google.auth.transport import requests
 from google.oauth2 import id_token
@@ -178,7 +178,7 @@ def login(form_data: OAuth2PasswordRequestForm = Depends()
 
 
 @router.post("/signup", tags=['Auth'])
-def signup(user: CreateUserModel):
+async def signup(user: CreateUserModel):
     db: Session = next(get_db())
     existing_user: User = db.query(User).filter(User.email == user.email).first()
 
@@ -190,11 +190,27 @@ def signup(user: CreateUserModel):
         )
     else:
         db_user = User(id=str(uuid4()), email=user.email, name=user.name, password=hash_password(user.password))
+        await send_verify_email([user.email], User)
         db.add(db_user)
         db.commit()
         db.close()
 
     return {"message": "Account created successfully"}
+
+
+@router.get("/verify_token", tags=['Auth'])
+async def email_verification(request:Request, token:str):
+    """Checks if the token is valid"""
+    user = await verify_token(token)
+    if user and not user.is_verified:
+        user.is_verified = True
+        await user.save()
+        return {"request": request, "email": user.email}
+
+    raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, 
+            detail="Invalid token",
+        )
 
 
 @router.post("/init_password_reset", tags=['Auth'])
@@ -279,6 +295,25 @@ async def send_password_reset_request_email(email: str, code: str):
     await send_email("Reset your YieldVest Password", [email], body)
 
 
+async def send_verify_email(email:List[str], instance: User):
+    token_data = {
+        "id": instance.id,
+        "email": instance.email,
+    }
+    token = jwt.encode(token_data, JWT_SECRET,)
+    app_url = os.getenv('API_URL')
+    verify_url = f"{app_url}/verify_token?token={token}"
+
+    body = "<html> <body><h4>Hello,</h4>"
+    body += "<p>Please verify your email on YieldVest</p>"
+    body += f"<p>Click <a href=\"{verify_url}\">here</a> to verify your email or copy "
+    body += f"this link to your browser to verify your email: {verify_url}</p>"
+    body += "<br/><br/><strong>If you didn't register on Yieldvest please ignore this email and nothing will happen."
+    body += "</strong><br/></body></html>"
+
+    await send_email("Verify your Email", [email], body)
+
+
 def authenticate(
         *,
         email: str,
@@ -323,3 +358,16 @@ def _create_token(
     payload["sub"] = str(sub)
 
     return jwt.encode(payload, JWT_SECRET, algorithm='HS256')
+
+# Decodes JWT token
+async def verify_token(token:str):
+    try: 
+        payload = jwt.decode(token, JWT_SECRET)
+        user = await User.get(id=payload.get("id"))
+    except:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, 
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"}
+        )
+    return user

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -300,7 +300,7 @@ async def send_verify_email(email:List[str], instance: User):
         "id": instance.id,
         "email": instance.email,
     }
-    token = jwt.encode(token_data, JWT_SECRET,)
+    token = jwt.encode(token_data, JWT_SECRET, algorithm='HS256')
     app_url = os.getenv('API_URL')
     verify_url = f"{app_url}/verify_token?token={token}"
 
@@ -362,7 +362,7 @@ def _create_token(
 # Decodes JWT token
 async def verify_token(token:str):
     try: 
-        payload = jwt.decode(token, JWT_SECRET)
+        payload = jwt.decode(token, JWT_SECRET, algorithm='HS256')
         user = await User.get(id=payload.get("id"))
     except:
         raise HTTPException(


### PR DESCRIPTION
1. Send a verify token to new users email to ensure they have the right mail.
2. Send a jwt token the users email.
3. Make the account active after verifying them.