### PR TITLE
fixed login issue

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -353,7 +353,7 @@ def create_access_token(*, sub: str) -> str:
 def create_refresh_token(*, sub: str) -> str:
     return _create_token(
         token_type="refresh_token",
-        lifetime=timedelta(days=float(ACCESS_TOKEN_EXPIRE_DAYS * 7)),
+        lifetime=timedelta(days=float(ACCESS_TOKEN_EXPIRE_DAYS * 3)),
         sub=sub,
     )
 


### PR DESCRIPTION
I don't know why this worked before but apparently the error was because the timedelta function value was too large. 

This is the error:
 >File "/home/dolapo/Python/myStockPlug/investment.web/backend/api/routes/auth.py", line 356, in create_refresh_token
 lifetime=timedelta(days=float(ACCESS_TOKEN_EXPIRE_DAYS * 7)),
>OverflowError: Python int too large to convert to C int

This is probably due to change of some values in the database, I don't know or maybe this wasn't merged to staging before.
My env values for ACCESS_TOKEN_EXPIRE_DAYS=60. Production is probably the same value but reducing it to 10 didn't work as well and produced the same error.