### PR TITLE
set canonical url for https://yieldvest.app/

### DIFF
--- a/frontend_next/pages/index.js
+++ b/frontend_next/pages/index.js
@@ -231,6 +231,11 @@ const Index = () => {
     <Layout isProtected disableStrictProtection>
       <Head>
         <title>Yieldvest - Top Recommended Stocks</title>
+        <link
+          rel="canonical"
+          href="https://yieldvest.app/"
+          key="canonical"
+        />
         <meta
           name="description"
           content="Get up to date recommendations on the best stocks to buy"


### PR DESCRIPTION
In this Pull Request, I set the canonical url to "https://yieldvest.app/", in order to fix the Google search console error saying "duplicate without user-selected canonical"